### PR TITLE
IRIX patches

### DIFF
--- a/src/hosts.c
+++ b/src/hosts.c
@@ -572,13 +572,21 @@ int dcc_parse_hosts(const char *where, const char *source_name,
 
         /* by default, mark the host up */
         curr->is_up = 1;
-
-        /* Store verbatim hostname */
+#ifdef __sgi
+	/* Store verbatim hostname */
+        if (!(curr->hostdef_string = strdup(token_start))) {
+            rs_log_crit("failed to allocate hostdef_string");
+            return EXIT_OUT_OF_MEMORY;
+        }
+#else
+	/* Store verbatim hostname */
         if (!(curr->hostdef_string = strndup(token_start, (size_t) token_len))) {
             rs_log_crit("failed to allocate hostdef_string");
             return EXIT_OUT_OF_MEMORY;
         }
+#endif
 
+      
         /* Link into list */
         if (*ret_prev) {
             (*ret_prev)->next = curr;

--- a/src/include_server_if.c
+++ b/src/include_server_if.c
@@ -92,8 +92,10 @@ int dcc_talk_to_include_server(char **argv, char ***files)
 
     strcpy(sa.sun_path, include_server_port);
     sa.sun_family = AF_UNIX;
+    struct sockaddr sa_reg;
+    memcpy(&sa_reg, &sa, sizeof(struct sockaddr));
 
-    if (dcc_connect_by_addr((struct sockaddr *) &sa, sizeof(sa), &fd))
+    if (dcc_connect_by_addr(&sa_reg, sizeof(sa_reg), &fd))
         return 1;
 
     /* TODO? switch include_server to use more appropriate token names */

--- a/src/snprintf.c
+++ b/src/snprintf.c
@@ -352,7 +352,9 @@ static size_t dopr(char *buffer, size_t maxlen, const char *format, va_list args
                 break;
             case 'X':
                 flags |= DP_F_UP;
+		goto x_fallthrough;
             case 'x':
+x_fallthrough:
                 flags |= DP_F_UNSIGNED;
                 if (cflags == DP_C_SHORT)
                     value = va_arg (args, unsigned int);
@@ -374,7 +376,9 @@ static size_t dopr(char *buffer, size_t maxlen, const char *format, va_list args
                 break;
             case 'E':
                 flags |= DP_F_UP;
+		goto e_fallthrough;
             case 'e':
+e_fallthrough:
                 if (cflags == DP_C_LDOUBLE)
                     fvalue = va_arg (args, LDOUBLE);
                 else
@@ -383,7 +387,9 @@ static size_t dopr(char *buffer, size_t maxlen, const char *format, va_list args
                 break;
             case 'G':
                 flags |= DP_F_UP;
+		goto g_fallthrough;
             case 'g':
+g_fallthrough:
                 if (cflags == DP_C_LDOUBLE)
                     fvalue = va_arg (args, LDOUBLE);
                 else


### PR DESCRIPTION
Default CFlags incl `-Wall`, you'll need to disable:

- `-Werror=char-subscripts`
- `-Werror=implicit-fallthrough`

@danielhams suggested fix for `HAVE_STRSIGNAL` issues:

```
`ac_cv_func_strsignal=no` either `export`ed before calling configure or pass it to `configure`
```